### PR TITLE
fix: EFI stub initrd handling & boot entry detection

### DIFF
--- a/config.c
+++ b/config.c
@@ -20,6 +20,27 @@ static CHAR16* trim(CHAR16 *s) {
     return s;
 }
 
+static int is_space16(CHAR16 c) {
+    return c == ' ' || c == '\t' || c == '\n' || c == '\r';
+}
+
+static void strip_inline_comment(CHAR16 *s) {
+    int in_quote = 0;
+    UINTN first = 0;
+    while (s[first] && is_space16(s[first])) first++;
+
+    for (UINTN i = 0; s[i]; i++) {
+        if (s[i] == '"') {
+            in_quote = !in_quote;
+            continue;
+        }
+        if (!in_quote && s[i] == '#' && i != first && (i == 0 || is_space16(s[i - 1]))) {
+            s[i] = '\0';
+            return;
+        }
+    }
+}
+
 static CHAR16* dup_path(CHAR16 *value) {
     if (!value) return NULL;
 
@@ -77,6 +98,8 @@ static int parse_color(CHAR16 *s, color_t *out) {
     return 1;
 }
 
+static CHAR16* read_text_file(CHAR16 *path);
+
 /* 'emilia-chan' */
 static UINTN parse_uint(CHAR16 *s) {
     UINTN n = 0;
@@ -117,6 +140,7 @@ static EFI_STATUS parse_entry(config_t *config, CHAR16 **lines, UINTN *idx, UINT
         if (eq) {
             *eq = '\0';
             CHAR16 *key = trim(line);
+            strip_inline_comment(eq + 1);
             CHAR16 *value = trim(eq + 1);
 
             if (efi_strcmp(key, L"name") == 0) {
@@ -276,6 +300,47 @@ static CHAR16* find_initrd(EFI_FILE_PROTOCOL *root, CHAR16 *dir, CHAR16 *kernel_
     return NULL;
 }
 
+static CHAR16* first_refind_cmdline(void) {
+    CHAR16 *buf = read_text_file(L"\\refind_linux.conf");
+    if (!buf) return NULL;
+
+    CHAR16 *start = buf;
+    while (*start) {
+        CHAR16 *end = start;
+        while (*end && *end != '\n') end++;
+        if (*end == '\n') *end = '\0';
+
+        CHAR16 *line = trim(start);
+        if (line[0] != '#' && line[0] != '\0') {
+            int quote = 0;
+            CHAR16 *cmd_start = NULL;
+            CHAR16 *cmd_end = NULL;
+            for (UINTN i = 0; line[i]; i++) {
+                if (line[i] != '"') continue;
+                quote++;
+                if (quote == 3) {
+                    cmd_start = line + i + 1;
+                } else if (quote == 4) {
+                    cmd_end = line + i;
+                    break;
+                }
+            }
+            if (cmd_start && cmd_end && cmd_end > cmd_start) {
+                *cmd_end = '\0';
+                CHAR16 *out = efi_strdup(cmd_start);
+                efi_free_pool(buf);
+                efi_log(L"config: imported Linux cmdline from \\refind_linux.conf");
+                return out;
+            }
+        }
+
+        start = end + 1;
+    }
+
+    efi_free_pool(buf);
+    return NULL;
+}
+
 static int scan_kernel_dir(config_t *config, EFI_FILE_PROTOCOL *root, CHAR16 *dir) {
     EFI_FILE_PROTOCOL *d = efi_open_dir(root, dir);
     if (!d) return 0;
@@ -296,7 +361,7 @@ static int scan_kernel_dir(config_t *config, EFI_FILE_PROTOCOL *root, CHAR16 *di
         if (initrd) efi_log(initrd);
 
         config_add_entry(config, efi_strdup(name), icon_path_for(L"unknown.png"),
-                         efi_strdup(path), initrd, NULL, NULL, 0);
+                         efi_strdup(path), initrd, first_refind_cmdline(), NULL, 0);
         added++;
     }
     d->Close(d);
@@ -561,6 +626,7 @@ static void apply_theme(config_t *config, CHAR16 *name) {
             if (eq) {
                 *eq = '\0';
                 CHAR16 *key = trim(line);
+                strip_inline_comment(eq + 1);
                 CHAR16 *value = trim(eq + 1);
                 if (efi_strcmp(key, L"theme") != 0)
                     apply_global(config, key, value);
@@ -657,6 +723,7 @@ EFI_STATUS config_parse(config_t *config) {
         if (eq) {
             *eq = '\0';
             CHAR16 *key = trim(line);
+            strip_inline_comment(eq + 1);
             CHAR16 *value = trim(eq + 1);
             apply_global(config, key, value);
             continue;

--- a/efi_helpers.c
+++ b/efi_helpers.c
@@ -69,6 +69,100 @@ CHAR16* efi_strchr(CHAR16 *s, CHAR16 c) {
     return (*s == c) ? s : NULL;
 }
 
+static int hex_digit(CHAR16 c) {
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+    if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+    return -1;
+}
+
+static int parse_hex_byte(CHAR16 *s, UINT8 *out) {
+    int hi = hex_digit(s[0]);
+    int lo = hex_digit(s[1]);
+    if (hi < 0 || lo < 0) return 0;
+    *out = (UINT8)((hi << 4) | lo);
+    return 1;
+}
+
+static int parse_partition_uuid(CHAR16 *s, EFI_GUID *out) {
+    if (!s || !out) return 0;
+    UINT8 raw[16];
+    int pos = 0;
+
+    for (UINTN i = 0; s[i];) {
+        if (s[i] == '-') {
+            i++;
+            continue;
+        }
+        if (!s[i + 1] || pos >= 16 || !parse_hex_byte(s + i, &raw[pos++]))
+            return 0;
+        i += 2;
+    }
+    if (pos != 16) return 0;
+
+    out->Data1 = ((UINT32)raw[0] << 24) | ((UINT32)raw[1] << 16) |
+                 ((UINT32)raw[2] << 8)  | raw[3];
+    out->Data2 = ((UINT16)raw[4] << 8) | raw[5];
+    out->Data3 = ((UINT16)raw[6] << 8) | raw[7];
+    for (int i = 0; i < 8; i++) out->Data4[i] = raw[8 + i];
+    return 1;
+}
+
+int efi_handle_matches_partition_uuid(EFI_HANDLE handle, CHAR16 *partition_uuid) {
+    if (!partition_uuid || partition_uuid[0] == '\0') return 1;
+
+    EFI_GUID want;
+    if (!parse_partition_uuid(partition_uuid, &want)) return 0;
+
+    EFI_DEVICE_PATH *dp = NULL;
+    if (EFI_ERROR(BS->HandleProtocol(handle, &gEfiDevicePathProtocolGuid, (void**)&dp)) || !dp)
+        return 0;
+
+    EFI_DEVICE_PATH *node = dp;
+    while (!IsDevicePathEnd(node)) {
+        if (DevicePathType(node) == MEDIA_DEVICE_PATH &&
+            DevicePathSubType(node) == MEDIA_HARDDRIVE_DP) {
+            HARDDRIVE_DEVICE_PATH *hd = (HARDDRIVE_DEVICE_PATH*)node;
+            if (hd->SignatureType == SIGNATURE_TYPE_GUID &&
+                CompareMem(hd->Signature, &want, sizeof(want)) == 0)
+                return 1;
+        }
+        node = (EFI_DEVICE_PATH*)((UINT8*)node + DevicePathNodeLength(node));
+    }
+
+    return 0;
+}
+
+EFI_DEVICE_PATH* efi_make_file_path(EFI_HANDLE handle, CHAR16 *filename) {
+    EFI_DEVICE_PATH *dp = NULL;
+    BS->HandleProtocol(handle, &gEfiDevicePathProtocolGuid, (void**)&dp);
+    if (!dp) return NULL;
+
+    UINTN dp_len    = DevicePathSize(dp) - sizeof(EFI_DEVICE_PATH_PROTOCOL);
+    UINTN fname_len = StrLen(filename) * sizeof(CHAR16);
+    UINTN fp_size   = sizeof(FILEPATH_DEVICE_PATH) + fname_len;
+    UINTN end_size  = sizeof(EFI_DEVICE_PATH_PROTOCOL);
+    UINTN total_len = dp_len + fp_size + end_size;
+
+    UINT8 *new_dp = efi_allocate_pool(total_len);
+    if (!new_dp) return NULL;
+
+    CopyMem(new_dp, dp, dp_len);
+
+    FILEPATH_DEVICE_PATH *fp = (FILEPATH_DEVICE_PATH*)(new_dp + dp_len);
+    fp->Header.Type    = MEDIA_DEVICE_PATH;
+    fp->Header.SubType = MEDIA_FILEPATH_DP;
+    SetDevicePathNodeLength(&fp->Header, (UINT16)fp_size);
+    StrCpy(fp->PathName, filename);
+
+    EFI_DEVICE_PATH_PROTOCOL *end = (EFI_DEVICE_PATH_PROTOCOL*)(new_dp + dp_len + fp_size);
+    end->Type    = END_DEVICE_PATH_TYPE;
+    end->SubType = END_ENTIRE_DEVICE_PATH_SUBTYPE;
+    SetDevicePathNodeLength(end, (UINT16)end_size);
+
+    return (EFI_DEVICE_PATH*)new_dp;
+}
+
 efi_file_t* efi_fopen(CHAR16 *path) {
     efi_file_t *file = efi_allocate_pool(sizeof(efi_file_t));
     if (!file) return NULL;
@@ -176,6 +270,47 @@ EFI_FILE_PROTOCOL* efi_open_dir(EFI_FILE_PROTOCOL *root, CHAR16 *path) {
     if (EFI_ERROR(root->Open(root, &d, path, EFI_FILE_MODE_READ, 0)))
         return NULL;
     return d;
+}
+
+EFI_DEVICE_PATH* efi_file_device_path(CHAR16 *path, CHAR16 *partition_uuid) {
+    EFI_HANDLE boot_handle = boot_device_handle();
+    EFI_FILE_PROTOCOL *root = open_root_on_handle(boot_handle);
+    if (root) {
+        if (efi_handle_matches_partition_uuid(boot_handle, partition_uuid) &&
+            efi_file_exists_root(root, path)) {
+            root->Close(root);
+            return efi_make_file_path(boot_handle, path);
+        }
+        root->Close(root);
+    }
+
+    UINTN count = 0;
+    EFI_HANDLE *handles = efi_locate_handle_buffer(
+        &gEfiSimpleFileSystemProtocolGuid, &count);
+    if (!handles) return NULL;
+
+    EFI_DEVICE_PATH *dp = NULL;
+    for (UINTN i = 0; i < count; i++) {
+        if (!efi_handle_matches_partition_uuid(handles[i], partition_uuid))
+            continue;
+
+        EFI_FILE_IO_INTERFACE *io = NULL;
+        if (EFI_ERROR(BS->HandleProtocol(handles[i],
+                &gEfiSimpleFileSystemProtocolGuid, (void**)&io)) || !io)
+            continue;
+
+        EFI_FILE_PROTOCOL *r = NULL;
+        if (EFI_ERROR(io->OpenVolume(io, &r)) || !r)
+            continue;
+
+        if (efi_file_exists_root(r, path))
+            dp = efi_make_file_path(handles[i], path);
+        r->Close(r);
+        if (dp) break;
+    }
+
+    efi_free_pool(handles);
+    return dp;
 }
 
 int efi_read_dirent(EFI_FILE_PROTOCOL *dir, CHAR16 *name_out, UINTN name_cap, int *is_dir) {

--- a/include/efi_helpers.h
+++ b/include/efi_helpers.h
@@ -31,6 +31,9 @@ EFI_FILE_PROTOCOL* efi_open_volume(UINTN index);
 int efi_file_exists_root(EFI_FILE_PROTOCOL *root, CHAR16 *path);
 EFI_FILE_PROTOCOL* efi_open_dir(EFI_FILE_PROTOCOL *root, CHAR16 *path);
 int efi_read_dirent(EFI_FILE_PROTOCOL *dir, CHAR16 *name_out, UINTN name_cap, int *is_dir);
+int efi_handle_matches_partition_uuid(EFI_HANDLE handle, CHAR16 *partition_uuid);
+EFI_DEVICE_PATH* efi_make_file_path(EFI_HANDLE handle, CHAR16 *filename);
+EFI_DEVICE_PATH* efi_file_device_path(CHAR16 *path, CHAR16 *partition_uuid);
 
 typedef struct {
     void *data;

--- a/include/windows_boot.h
+++ b/include/windows_boot.h
@@ -20,6 +20,7 @@ EFI_DEVICE_PATH* windows_make_file_path(EFI_HANDLE handle,
 
 EFI_STATUS efi_chainload(EFI_HANDLE image_handle,
                          EFI_SYSTEM_TABLE *system_table,
-                         CHAR16 *path);
+                         CHAR16 *path,
+                         CHAR16 *partition_uuid);
 
 #endif

--- a/linux_boot.c
+++ b/linux_boot.c
@@ -30,6 +30,40 @@ static UINTN strlen16(CHAR16 *s) {
     return len;
 }
 
+static int contains_token16(CHAR16 *s, const CHAR16 *needle) {
+    if (!s || !needle) return 0;
+    for (UINTN i = 0; s[i]; i++) {
+        UINTN j = 0;
+        while (needle[j] && s[i + j] == needle[j]) j++;
+        if (!needle[j]) return 1;
+    }
+    return 0;
+}
+
+static CHAR16* efi_stub_options(boot_entry_t *entry) {
+    if (!entry->initrd_path || contains_token16(entry->cmdline, L"initrd="))
+        return entry->cmdline;
+
+    UINTN initrd_key_len = strlen16(L"initrd=");
+    UINTN initrd_len = strlen16(entry->initrd_path);
+    UINTN cmd_len = entry->cmdline ? strlen16(entry->cmdline) : 0;
+    UINTN total = initrd_key_len + initrd_len + (cmd_len ? 1 + cmd_len : 0);
+    CHAR16 *opts = efi_allocate_pool((total + 1) * sizeof(CHAR16));
+    if (!opts) return entry->cmdline;
+
+    UINTN k = 0;
+    CHAR16 *key = L"initrd=";
+    for (UINTN i = 0; key[i]; i++) opts[k++] = key[i];
+    for (UINTN i = 0; entry->initrd_path[i]; i++) opts[k++] = entry->initrd_path[i];
+    if (cmd_len) {
+        opts[k++] = ' ';
+        for (UINTN i = 0; entry->cmdline[i]; i++) opts[k++] = entry->cmdline[i];
+    }
+    opts[k] = '\0';
+    efi_log(L"linux: synthesized EFI-stub initrd= option");
+    return opts;
+}
+
 static void* load_kernel_file(CHAR16 *path, UINTN *size_out) {
     efi_file_buffer_t *buf = efi_load_file(path);
     if (!buf) return NULL;
@@ -150,35 +184,33 @@ EFI_STATUS linux_boot(boot_entry_t *entry, EFI_SYSTEM_TABLE *st) {
         return EFI_NOT_FOUND;
     }
 
-    UINT32 initrd_addr = 0, initrd_size = 0;
-    if (entry->initrd_path) {
-        efi_log(L"linux: loading initrd");
-        status = linux_load_initrd_impl(entry->initrd_path, &initrd_addr, &initrd_size);
-        if (EFI_ERROR(status)) {
-            efi_log(L"WARN: initrd load failed - continuing without it");
-            efi_print(L"Warning: Could not load initrd\r\n");
-        }
-    }
-
     UINT8 *kernel = (UINT8*)kernel_data;
 
     if (kernel[0] == 'M' && kernel[1] == 'Z') {
         EFI_HANDLE kernel_handle;
 
         efi_log(L"linux: PE/UKI image, LoadImage()");
-        status = BS->LoadImage(FALSE, IH, NULL, kernel_data, kernel_size, &kernel_handle);
+        EFI_DEVICE_PATH *kernel_dp = efi_file_device_path(entry->kernel_path, NULL);
+        if (kernel_dp) {
+            status = BS->LoadImage(FALSE, IH, kernel_dp, NULL, 0, &kernel_handle);
+            efi_free_pool(kernel_dp);
+        } else {
+            efi_log(L"WARN: could not build kernel device path - falling back to source buffer");
+            status = BS->LoadImage(FALSE, IH, NULL, kernel_data, kernel_size, &kernel_handle);
+        }
         if (EFI_ERROR(status)) {
             efi_log(L"ERROR: LoadImage failed (not a valid EFI image?)");
             efi_print(L"LoadImage failed\r\n");
             return status;
         }
 
-        if (entry->cmdline) {
+        CHAR16 *load_options = efi_stub_options(entry);
+        if (load_options) {
             EFI_LOADED_IMAGE *loaded;
             status = BS->HandleProtocol(kernel_handle, &gEfiLoadedImageProtocolGuid, (void**)&loaded);
             if (!EFI_ERROR(status)) {
-                loaded->LoadOptions     = entry->cmdline;
-                loaded->LoadOptionsSize = (UINT32)((strlen16(entry->cmdline) + 1) * sizeof(CHAR16));
+                loaded->LoadOptions     = load_options;
+                loaded->LoadOptionsSize = (UINT32)((strlen16(load_options) + 1) * sizeof(CHAR16));
             }
         }
 
@@ -187,6 +219,16 @@ EFI_STATUS linux_boot(boot_entry_t *entry, EFI_SYSTEM_TABLE *st) {
 
         efi_log(L"ERROR: kernel StartImage returned - boot failed");
         return status;
+    }
+
+    UINT32 initrd_addr = 0, initrd_size = 0;
+    if (entry->initrd_path) {
+        efi_log(L"linux: loading initrd");
+        status = linux_load_initrd_impl(entry->initrd_path, &initrd_addr, &initrd_size);
+        if (EFI_ERROR(status)) {
+            efi_log(L"WARN: initrd load failed - continuing without it");
+            efi_print(L"Warning: Could not load initrd\r\n");
+        }
     }
 
     status = linux_setup_boot_params(kernel_data, kernel_size,

--- a/visor
+++ b/visor
@@ -240,6 +240,34 @@ validate_config_file() {
         print msg > "/dev/stderr"
         exit 1
     }
+    function is_space(c) {
+        return c == " " || c == "\t" || c == "\r" || c == "\n"
+    }
+    function strip_comment(s,    i,c,in_quote,first,eq,after_eq,prev) {
+        first = 1
+        while (first <= length(s) && is_space(substr(s, first, 1))) first++
+
+        eq = index(s, "=")
+        after_eq = 0
+        if (eq > 0) {
+            after_eq = eq + 1
+            while (after_eq <= length(s) && is_space(substr(s, after_eq, 1))) after_eq++
+        }
+
+        in_quote = 0
+        for (i = 1; i <= length(s); i++) {
+            c = substr(s, i, 1)
+            if (c == "\"") {
+                in_quote = !in_quote
+                continue
+            }
+            if (!in_quote && c == "#" && i != first && i != after_eq) {
+                prev = (i > 1) ? substr(s, i - 1, 1) : ""
+                if (is_space(prev)) return substr(s, 1, i - 1)
+            }
+        }
+        return s
+    }
     function trim(s) {
         sub(/^[ \t]+/, "", s)
         sub(/[ \t\r]+$/, "", s)
@@ -248,6 +276,7 @@ validate_config_file() {
     BEGIN { in_entry=0; have_name=0; have_kernel=0 }
     {
         sub(/\r$/, "")
+        $0 = strip_comment($0)
         line = trim($0)
         if (line == "" || substr(line,1,1) == "#") next
         if (in_entry) {
@@ -259,7 +288,7 @@ validate_config_file() {
                 have_kernel=0
                 next
             }
-            if (line ~ /^[^=]+=[^=]*$/) {
+            if (index(line, "=") > 1) {
                 split(line, kv, "=")
                 key = trim(kv[1])
                 if (key == "name") have_name=1
@@ -275,7 +304,7 @@ validate_config_file() {
             have_kernel=0
             next
         }
-        if (line ~ /^[^=]+=[^=]*$/) next
+        if (index(line, "=") > 1) next
         fail(FILENAME ": invalid top-level line: " line)
     }
     END {

--- a/windows_boot.c
+++ b/windows_boot.c
@@ -9,65 +9,10 @@ extern EFI_SYSTEM_TABLE *ST;
 extern EFI_HANDLE IH;
 
 EFI_DEVICE_PATH* windows_make_file_path(EFI_HANDLE handle, CHAR16 *filename) {
-    EFI_DEVICE_PATH *dp = NULL;
-    BS->HandleProtocol(handle, &gEfiDevicePathProtocolGuid, (void**)&dp);
-    if (!dp) return NULL;
-
-    UINTN dp_len    = DevicePathSize(dp) - sizeof(EFI_DEVICE_PATH_PROTOCOL);
-    UINTN fname_len = StrLen(filename) * sizeof(CHAR16);
-    UINTN fp_size   = sizeof(FILEPATH_DEVICE_PATH) + fname_len;
-    UINTN end_size  = sizeof(EFI_DEVICE_PATH_PROTOCOL);
-    UINTN total_len = dp_len + fp_size + end_size;
-
-    UINT8 *new_dp = efi_allocate_pool(total_len);
-    if (!new_dp) return NULL;
-
-    CopyMem(new_dp, dp, dp_len);
-
-    FILEPATH_DEVICE_PATH *fp = (FILEPATH_DEVICE_PATH*)(new_dp + dp_len);
-    fp->Header.Type    = MEDIA_DEVICE_PATH;
-    fp->Header.SubType = MEDIA_FILEPATH_DP;
-    SetDevicePathNodeLength(&fp->Header, (UINT16)fp_size);
-    StrCpy(fp->PathName, filename);
-
-    EFI_DEVICE_PATH_PROTOCOL *end = (EFI_DEVICE_PATH_PROTOCOL*)(new_dp + dp_len + fp_size);
-    end->Type    = END_DEVICE_PATH_TYPE;
-    end->SubType = END_ENTIRE_DEVICE_PATH_SUBTYPE;
-    SetDevicePathNodeLength(end, (UINT16)end_size);
-
-    return (EFI_DEVICE_PATH*)new_dp;
-}
-
-static EFI_HANDLE find_esp(void) {
-    UINTN count;
-    EFI_HANDLE *handles = efi_locate_handle_buffer(&gEfiSimpleFileSystemProtocolGuid, &count);
-    if (!handles) return NULL;
-
-    for (UINTN i = 0; i < count; i++) {
-        EFI_SIMPLE_FILE_SYSTEM_PROTOCOL *fs;
-        EFI_STATUS status = BS->HandleProtocol(handles[i], &gEfiSimpleFileSystemProtocolGuid, (void**)&fs);
-        if (EFI_ERROR(status)) continue;
-
-        EFI_FILE_PROTOCOL *root;
-        status = fs->OpenVolume(fs, &root);
-        if (EFI_ERROR(status)) continue;
-
-        if (efi_file_exists(L"\\EFI")) {
-            root->Close(root);
-            EFI_HANDLE esp = handles[i];
-            efi_free_pool(handles);
-            return esp;
-        }
-        root->Close(root);
-    }
-
-    efi_free_pool(handles);
-    return NULL;
+    return efi_make_file_path(handle, filename);
 }
 
 EFI_STATUS windows_find_bootmgr(CHAR16 *partition_uuid, EFI_DEVICE_PATH **bootmgr_path) {
-    (void)partition_uuid;
-
     CHAR16 *paths[] = {
         L"\\EFI\\Microsoft\\Boot\\bootmgfw.efi",
         L"\\EFI\\BOOT\\bootmgfw.efi",
@@ -75,16 +20,9 @@ EFI_STATUS windows_find_bootmgr(CHAR16 *partition_uuid, EFI_DEVICE_PATH **bootmg
         NULL
     };
 
-    EFI_HANDLE esp = find_esp();
-    if (!esp) return EFI_NOT_FOUND;
-
     for (int i = 0; paths[i]; i++) {
-        efi_file_t *f = efi_fopen(paths[i]);
-        if (f) {
-            efi_fclose(f);
-            *bootmgr_path = windows_make_file_path(esp, paths[i]);
-            if (*bootmgr_path) return EFI_SUCCESS;
-        }
+        *bootmgr_path = efi_file_device_path(paths[i], partition_uuid);
+        if (*bootmgr_path) return EFI_SUCCESS;
     }
 
     return EFI_NOT_FOUND;
@@ -92,7 +30,8 @@ EFI_STATUS windows_find_bootmgr(CHAR16 *partition_uuid, EFI_DEVICE_PATH **bootmg
 
 EFI_STATUS efi_chainload(EFI_HANDLE image_handle,
                           EFI_SYSTEM_TABLE *system_table,
-                          CHAR16 *path) {
+                          CHAR16 *path,
+                          CHAR16 *partition_uuid) {
     (void)system_table;
 
     efi_log(L"win: chainloading via device path");
@@ -101,31 +40,7 @@ EFI_STATUS efi_chainload(EFI_HANDLE image_handle,
     efi_print(path);
     efi_print(L"\r\n");
 
-    UINTN count = 0;
-    EFI_HANDLE *handles = efi_locate_handle_buffer(&gEfiSimpleFileSystemProtocolGuid, &count);
-    if (!handles) {
-        efi_log(L"ERROR: no filesystems found to locate the EFI binary");
-        efi_print(L"No filesystems\r\n");
-        return EFI_NOT_FOUND;
-    }
-
-    EFI_DEVICE_PATH *dp = NULL;
-    for (UINTN i = 0; i < count; i++) {
-        EFI_SIMPLE_FILE_SYSTEM_PROTOCOL *fs;
-        if (EFI_ERROR(BS->HandleProtocol(handles[i],
-                &gEfiSimpleFileSystemProtocolGuid, (void**)&fs))) continue;
-        EFI_FILE_PROTOCOL *root;
-        if (EFI_ERROR(fs->OpenVolume(fs, &root))) continue;
-        EFI_FILE_PROTOCOL *fh;
-        EFI_STATUS s = root->Open(root, &fh, path, EFI_FILE_MODE_READ, 0);
-        root->Close(root);
-        if (!EFI_ERROR(s)) {
-            fh->Close(fh);
-            dp = windows_make_file_path(handles[i], path);
-            break;
-        }
-    }
-    efi_free_pool(handles);
+    EFI_DEVICE_PATH *dp = efi_file_device_path(path, partition_uuid);
 
     if (!dp) {
         efi_log(L"ERROR: EFI binary not found on any volume");
@@ -158,7 +73,7 @@ EFI_STATUS windows_boot(boot_entry_t *entry, EFI_SYSTEM_TABLE *st) {
     efi_print(L"Booting Windows\r\n");
 
     if (entry->kernel_path) {
-        return efi_chainload(IH, st, entry->kernel_path);
+        return efi_chainload(IH, st, entry->kernel_path, entry->uuid);
     }
 
     efi_log(L"win: no explicit path, searching for bootmgfw.efi");


### PR DESCRIPTION
this fixes a few boot handling issues i ran into while testing raw efi stub kernels and dual-boot setups.

changes:
- pass `initrd=` through load options for efi stub kernels when an entry has a separate initrd
- load efi stub kernels by device path when possible
- make the windows `uuid` hint actually constrain boot manager lookup to the matching partition
- allow inline comments in config values without breaking paths/colors
- make `visor config validate` accept realistic kernel args like `root=UUID=...`
- reuse `refind_linux.conf` cmdline options when auto-detecting raw linux kernels

i split the lower-level device path helper out so linux and windows boot paths can share the same lookup behavior.