### PR TITLE
loader_iface: remove stale include of nonexistent version.h

### DIFF
--- a/src/include/loader_iface.h
+++ b/src/include/loader_iface.h
@@ -4,7 +4,6 @@
 #include <efi.h>
 #include "gui.h"
 #include "config.h"
-#include "version.h"
 
 #define VISOR_LOADER_INFO L"Visor " VISOR_VERSION
 


### PR DESCRIPTION
VISOR_VERSION is provided by the Makefile via -DVISOR_VERSION; no version.h exists (or is generated) anywhere in the repository, so building from a fresh clone fails with:

    src/include/loader_iface.h:7:10: fatal error: version.h: No such file or directory

Drop the leftover include so the source builds out of the box.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an unnecessary internal include without changing loader functionality or public declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->