### PR TITLE
config: fix #RRGGBB colour values being eaten as inline comments

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -29,15 +29,12 @@ static int is_space16(CHAR16 c) {
 
 static void strip_inline_comment(CHAR16 *s) {
     int in_quote = 0;
-    UINTN first = 0;
-    while (s[first] && is_space16(s[first])) first++;
-
     for (UINTN i = 0; s[i]; i++) {
         if (s[i] == '"') {
             in_quote = !in_quote;
             continue;
         }
-        if (!in_quote && s[i] == '#' && (i == 0 || is_space16(s[i - 1]))) {
+        if (!in_quote && s[i] == '#' && i > 0 && is_space16(s[i - 1])) {
             s[i] = '\0';
             return;
         }


### PR DESCRIPTION
strip_inline_comment() is only ever called on the value side of a key=value line (eq + 1). Its i == 0 clause - meant for whole-line comments - therefore treats a leading '#' in the value as a comment start and truncates it, so the documented #RRGGBB colour form (title_color=#7AA2F7) is silently deleted. parse_color() then fails with 'WARN: invalid <key>' and the key falls back to its default.

Drop the line-start clause so '#' only starts a comment when preceded by whitespace, matching the rule stated in boot.conf.example and docs/boot.conf.schema.json ("inside a value it only counts when preceded by whitespace"). Bare hex without '#' keeps working.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved values beginning with `#` when parsing configuration entries.
  * Inline comments are now recognized only when the `#` marker follows whitespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->