### PR TITLE
fix(install): use findmnt -U (--uniq) to ignore over-mounted ESP mounts

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -210,9 +210,9 @@ fi
 boot_fs_type() {
     local t=""
     if mountpoint -q /boot 2>/dev/null; then
-        t="$(findmnt -no FSTYPE /boot 2>/dev/null || true)"
+        t="$(findmnt -Uno FSTYPE /boot 2>/dev/null || true)"
     fi
-    [ -z "$t" ] && t="$(findmnt -no FSTYPE / 2>/dev/null || true)"
+    [ -z "$t" ] && t="$(findmnt -Uno FSTYPE / 2>/dev/null || true)"
     echo "$t"
 }
 
@@ -348,7 +348,7 @@ detect_esp() {
     local m
     for m in /boot/efi /efi /boot; do
         if mountpoint -q "$m" 2>/dev/null && \
-           [ "$(findmnt -no FSTYPE "$m" 2>/dev/null)" = vfat ]; then
+           [ "$(findmnt -Uno FSTYPE "$m" 2>/dev/null)" = vfat ]; then
             echo "$m"; return
         fi
     done
@@ -502,7 +502,7 @@ if [ "$DO_BOOT_ENTRY" -eq 1 ]; then
     if ! command -v efibootmgr >/dev/null 2>&1; then
         warn "efibootmgr not installed; skipping boot entry."
     else
-        src="$(findmnt -no SOURCE "$ESP")" || die "Cannot resolve ESP device."
+        src="$(findmnt -Uno SOURCE "$ESP")" || die "Cannot resolve ESP device."
         disk="/dev/$(lsblk -no PKNAME "$src")"
         partnum="$(lsblk -no PARTN "$src" 2>/dev/null || \
                    echo "$src" | grep -o '[0-9]*$')"


### PR DESCRIPTION
### Issue for this PR

Closes #26

### Type of change

- [x] Bug fix

### What does this PR do?

`install.sh` aborts at the "Firmware boot entry" step with `lsblk: systemd-1` / `/dev/nvme0n1p3: No such file or directory` (exit 32) when the ESP mount is over-mounted (e.g. by systemd's `systemd-1` autofs or a stacked mount). `findmnt -no SOURCE "$ESP"` returns the over-mount's source (`systemd-1`) instead of the real block device, and the subsequent `lsblk -no PKNAME` fails, tripping `set -euo pipefail`.

This PR adds `-U` (`--uniq`) to the `findmnt` calls so they ignore over-mounted duplicates and resolve the topmost mount:

- `install.sh:213` — `findmnt -Uno FSTYPE /boot`
- `install.sh:215` — `findmnt -Uno FSTYPE /`
- `install.sh:351` — `findmnt -Uno FSTYPE "$m"`
- `install.sh:505` — `findmnt -Uno SOURCE "$ESP"`

The `lsblk` calls are left unchanged — `lsblk` has no `-u`/`-U` option; once `findmnt -U` returns the real device, `lsblk -no PKNAME`/`PARTN` work on it.

### How did you verify your code works?

- `bash -n install.sh` passes.
- Diff against upstream `main` shows exactly the 4 intended lines changed; the upstream `partnum` guard stays untouched (not part of this PR).
- Pushed blob verified byte-identical to the patched local copy (commit `0c69b75`); file mode `100755` preserved.
- The failure was reproduced on a system where the ESP is over-mounted by systemd autofs; with `-U`, `findmnt -Uno SOURCE` resolves the real device (`/dev/nvme0n1p3`) and `lsblk -no PKNAME`/`PARTN` succeed.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved boot configuration detection by resolving filesystem types, EFI System Partition mounts, and boot-entry devices using device UUIDs.
  - This helps ensure the installer identifies the correct storage devices more reliably, especially when mount paths may vary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->